### PR TITLE
mgr/dashboard: Add Patternfly and Patternfly support

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/angular.json
+++ b/src/pybind/mgr/dashboard/frontend/angular.json
@@ -25,9 +25,16 @@
               "node_modules/ng2-toastr/bundles/ng2-toastr.min.css",
               "node_modules/fork-awesome/css/fork-awesome.css",
               "node_modules/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.css",
+	      "node_modules/patternfly/dist/css/patternfly.min.css",
+	      "node_modules/patternfly/dist/css/patternfly-additions.min.css",
+	      "node_modules/patternfly-ng/dist/css/patternfly-ng.min.css",
               "src/styles.scss"
             ],
             "scripts": [
+	      "node_modules/jquery/dist/jquery.min.js",
+	      "node_modules/bootstrap/dist/js/bootstrap.min.js",
+	      "node_modules/c3/c3.min.js",
+	      "node_modules/d3/d3.min.js",
               "node_modules/chart.js/dist/Chart.bundle.js"
             ]
           },

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -56,6 +56,8 @@
     "ng2-charts": "1.6.0",
     "ng2-toastr": "zzakir/ng2-toastr#0eafd72",
     "ngx-bootstrap": "2.0.5",
+    "patternfly": "3.52.0",
+    "patternfly-ng": "4.0.1",
     "rxjs": "6.2.1",
     "rxjs-compat": "6.2.1",
     "zone.js": "0.8.26"


### PR DESCRIPTION
Including both patternfly and patternfly-ng modules. Let's see what we can get from them.