### PR TITLE
mgr/dashboard: Luminous dashboard pool fix

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnChanges, OnInit, TemplateRef, ViewChild } from '@angular/core';
 
-import * as _ from 'lodash';
 import * as moment from 'moment';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap';
 import { of } from 'rxjs';

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/erasure-code-profile.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/erasure-code-profile.service.ts
@@ -6,7 +6,6 @@ import { ApiModule } from './api.module';
 @Injectable({
   providedIn: ApiModule
 })
-@Injectable()
 export class ErasureCodeProfileService {
   constructor(private http: HttpClient) {}
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
@@ -1,4 +1,4 @@
-import { HTTP_INTERCEPTORS, HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';

--- a/src/pybind/mgr/dashboard/frontend/tslint.json
+++ b/src/pybind/mgr/dashboard/frontend/tslint.json
@@ -41,6 +41,7 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
+    "no-unused-variable": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,


### PR DESCRIPTION
mgr/dashboard: pool creation fix + cleanup
- erasure-code-profile.service.ts: pool creation fix when 
frontend is running in PROD mode.
- TSlint "no-unused-variable" rule added.
- Cleanup: unused imports and variables.

Fixes: https://tracker.ceph.com/issues/36544

Signed-off-by: Alfonso Martínez <almartin@redhat.com>