### PR TITLE
Fix rhbz#1647812 and package-lock.json

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1591,24 +1591,27 @@ void DaemonServer::got_mgr_map()
   Mutex::Locker l(lock);
   set<std::string> have;
   cluster_state.with_mgrmap([&](const MgrMap& mgrmap) {
+      auto md_update = [&] (DaemonKey key) {
+        std::ostringstream oss;
+        auto c = new MetadataUpdate(daemon_state, key);
+        oss << "{\"prefix\": \"mgr metadata\", \"who\": \""
+              << key.second << "\"}";
+        monc->start_mon_command({oss.str()}, {}, &c->outbl, &c->outs, c);
+      };
       if (mgrmap.active_name.size()) {
 	DaemonKey key("mgr", mgrmap.active_name);
 	have.insert(mgrmap.active_name);
-	if (!daemon_state.exists(key)) {
-	  auto daemon = std::make_shared<DaemonState>(daemon_state.types);
-	  daemon->key = key;
-	  daemon_state.insert(daemon);
-	  dout(10) << "added missing " << key << dendl;
+	if (!daemon_state.exists(key) && !daemon_state.is_updating(key)) {
+	  md_update(key);
+	  dout(10) << "triggered addition of " << key << " via metadata update" << dendl;
 	}
       }
       for (auto& i : mgrmap.standbys) {
-	DaemonKey key("mgr", i.second.name);
+        DaemonKey key("mgr", i.second.name);
 	have.insert(i.second.name);
-	if (!daemon_state.exists(key)) {
-	  auto daemon = std::make_shared<DaemonState>(daemon_state.types);
-	  daemon->key = key;
-	  daemon_state.insert(daemon);
-	  dout(10) << "added missing " << key << dendl;
+	if (!daemon_state.exists(key) && !daemon_state.is_updating(key)) {
+	  md_update(key);
+	  dout(10) << "triggered addition of " << key << " via metadata update" << dendl;
 	}
       }
     });

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -429,7 +429,6 @@ void Mgr::handle_osd_map()
       }
 
       if (update_meta) {
-        daemon_state.notify_updating(k);
         auto c = new MetadataUpdate(daemon_state, k);
         std::ostringstream cmd;
         cmd << "{\"prefix\": \"osd metadata\", \"id\": "
@@ -561,7 +560,6 @@ void Mgr::handle_fs_map(MFSMap* m)
     }
 
     if (update) {
-      daemon_state.notify_updating(k);
       auto c = new MetadataUpdate(daemon_state, k);
 
       // Older MDS daemons don't have addr in the metadata, so

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -74,7 +74,7 @@ void MetadataUpdate::finish(int r)
 {
   daemon_state.clear_updating(key);
   if (r == 0) {
-    if (key.first == "mds" || key.first == "osd") {
+    if (key.first == "mds" || key.first == "osd" || key.first == "mgr") {
       json_spirit::mValue json_result;
       bool read_ok = json_spirit::read(
           outbl.to_str(), json_result);
@@ -99,7 +99,7 @@ void MetadataUpdate::finish(int r)
       if (daemon_state.exists(key)) {
         state = daemon_state.get(key);
 	Mutex::Locker l(state->lock);
-        if (key.first == "mds") {
+        if (key.first == "mds" || key.first == "mgr") {
           daemon_meta.erase("name");
         } else if (key.first == "osd") {
           daemon_meta.erase("id");
@@ -114,7 +114,7 @@ void MetadataUpdate::finish(int r)
         state->key = key;
         state->hostname = daemon_meta.at("hostname").get_str();
 
-        if (key.first == "mds") {
+        if (key.first == "mds" || key.first == "mgr") {
           daemon_meta.erase("name");
         } else if (key.first == "osd") {
           daemon_meta.erase("id");

--- a/src/mgr/Mgr.h
+++ b/src/mgr/Mgr.h
@@ -123,7 +123,10 @@ public:
   std::string outs;
 
   MetadataUpdate(DaemonStateIndex &daemon_state_, const DaemonKey &key_)
-    : daemon_state(daemon_state_), key(key_) {}
+    : daemon_state(daemon_state_), key(key_)
+  {
+      daemon_state.notify_updating(key);
+  }
 
   void set_default(const std::string &k, const std::string &v)
   {

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -776,7 +776,7 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
     f->flush(rdata);
   } else if (prefix == "mgr metadata") {
     string name;
-    cmd_getval(g_ceph_context, cmdmap, "id", name);
+    cmd_getval(g_ceph_context, cmdmap, "who", name);
     if (name.size() > 0 && !map.have_name(name)) {
       ss << "mgr." << name << " does not exist";
       r = -ENOENT;
@@ -787,7 +787,7 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
     boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json-pretty"));
     if (name.size()) {
       f->open_object_section("mgr_metadata");
-      f->dump_string("id", name);
+      f->dump_string("name", name);
       r = dump_metadata(name, f.get(), &ss);
       if (r < 0)
         goto reply;
@@ -797,7 +797,7 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
       f->open_array_section("mgr_metadata");
       for (auto& i : map.get_all_names()) {
 	f->open_object_section("mgr");
-	f->dump_string("id", i);
+	f->dump_string("name", i);
 	r = dump_metadata(i, f.get(), NULL);
 	if (r == -EINVAL || r == -ENOENT) {
 	  // Drop error, continue to get other daemons' metadata

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1088,7 +1088,7 @@ COMMAND("mgr module enable "						\
 COMMAND("mgr module disable "						\
 	"name=module,type=CephString",
 	"disable mgr module", "mgr", "rw", "cli,rest")
-COMMAND("mgr metadata name=id,type=CephString,req=false",
+COMMAND("mgr metadata name=who,type=CephString,req=false",
 	"dump metadata for all daemons or a specific daemon",
 	"mgr", "r", "cli,rest")
 COMMAND("mgr count-metadata name=property,type=CephString",

--- a/src/pybind/mgr/dashboard/frontend/package-lock.json
+++ b/src/pybind/mgr/dashboard/frontend/package-lock.json
@@ -436,6 +436,11 @@
       "resolved": "https://registry.npmjs.org/@swimlane/ngx-datatable/-/ngx-datatable-13.1.0.tgz",
       "integrity": "sha512-UJRXbRkLDq9oweY/ZlmU5X7MtnD3+7/nuCBx2cvsbkDKj6cECy+m1O/EfAGEh5++zZ55QWmX4rj7nM4G9pst/w=="
     },
+    "@types/detect-browser": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npmjs.org/@types/detect-browser/-/detect-browser-2.0.1.tgz",
+      "integrity": "sha512-n9jH0zq0DGOlu/B9tSpK+DKwaW9uozF96hy3zYibvxVqQDX5KOJJn6qns/G+k3UwfEQVYZuV3Rz+Z2fXMQ0ang=="
+    },
     "@types/jasmine": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.8.tgz",
@@ -3144,6 +3149,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
+    },
+    "detect-browser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-3.0.1.tgz",
+      "integrity": "sha512-L6b76EfUxnoxGHM5Vz7nrshQPIbOHtitDWpGufrp5srQdJrEYi1xpUVZeFbfssWAJvUWo/iDIVlz8hOP4Z8OCw=="
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -9103,6 +9113,695 @@
       "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
       "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
       "dev": true
+    },
+    "rcue": {
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/rcue/-/rcue-3.48.1.tgz",
+      "integrity": "sha1-WJYbLVG/ez9uS8ETufYUiwWWP+M=",
+      "requires": {
+        "bootstrap": "~3.3.7",
+        "bootstrap-datepicker": "^1.7.1",
+        "bootstrap-select": "^1.12.2",
+        "bootstrap-slider": "^9.9.0",
+        "bootstrap-switch": "~3.3.4",
+        "bootstrap-touchspin": "~3.1.1",
+        "c3": "~0.4.11",
+        "d3": "~3.5.17",
+        "datatables.net": "^1.10.15",
+        "datatables.net-colreorder": "^1.4.1",
+        "datatables.net-colreorder-bs": "~1.3.2",
+        "datatables.net-select": "~1.2.0",
+        "drmonty-datatables-colvis": "~1.1.2",
+        "eonasdan-bootstrap-datetimepicker": "^4.17.47",
+        "font-awesome": "^4.7.0",
+        "google-code-prettify": "~1.0.5",
+        "jquery": "~3.2.1",
+        "jquery-match-height": "^0.7.2",
+        "moment": "^2.19.1",
+        "moment-timezone": "^0.4.1",
+        "patternfly": "3.48.1",
+        "patternfly-bootstrap-combobox": "~1.1.7",
+        "patternfly-bootstrap-treeview": "~2.1.0"
+      },
+      "dependencies": {
+        "bootstrap": {
+          "version": "3.3.7",
+          "resolved": "http://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+          "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
+        },
+        "bootstrap-datepicker": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.8.0.tgz",
+          "integrity": "sha512-213St/G8KT3mjs4qu4qwww74KWysMaIeqgq5OhrboZjIjemIpyuxlSo9FNNI5+KzpkkxkRRba+oewiRGV42B1A==",
+          "optional": true,
+          "requires": {
+            "jquery": ">=1.7.1 <4.0.0"
+          }
+        },
+        "bootstrap-select": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/bootstrap-select/-/bootstrap-select-1.13.1.tgz",
+          "integrity": "sha1-9ZwCkm+1rGNWudHNvFOEwvAT2bo=",
+          "optional": true
+        },
+        "bootstrap-slider": {
+          "version": "9.10.0",
+          "resolved": "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-9.10.0.tgz",
+          "integrity": "sha1-EQPWvADPv6jPyaJZmrUYxVZD2j8=",
+          "optional": true
+        },
+        "bootstrap-switch": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/bootstrap-switch/-/bootstrap-switch-3.3.4.tgz",
+          "integrity": "sha1-cOCusqh3wNx2aZHeEI4hcPwpov8=",
+          "optional": true
+        },
+        "bootstrap-touchspin": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/bootstrap-touchspin/-/bootstrap-touchspin-3.1.1.tgz",
+          "integrity": "sha1-l3nerHKq9Xfl52K4USx0fIcdlZc=",
+          "optional": true
+        },
+        "c3": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/c3/-/c3-0.4.23.tgz",
+          "integrity": "sha512-fI6hbx1QoATU0gRQtPWsUGWX+ssXhxGH1ogew32KjVmGHFE4WmfmBkh+RkuHDoeCIoGFon7XTpKcwUZpBGW4mQ==",
+          "optional": true,
+          "requires": {
+            "d3": "~3.5.0"
+          }
+        },
+        "d3": {
+          "version": "3.5.17",
+          "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+          "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=",
+          "optional": true
+        },
+        "datatables.net": {
+          "version": "1.10.16",
+          "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.16.tgz",
+          "integrity": "sha1-SwUtEIKCQmG2ju2dInQbcR09JGk=",
+          "requires": {
+            "jquery": ">=1.7"
+          }
+        },
+        "datatables.net-bs": {
+          "version": "1.10.16",
+          "resolved": "https://registry.npmjs.org/datatables.net-bs/-/datatables.net-bs-1.10.16.tgz",
+          "integrity": "sha1-sIVPWzdPcTrj20FWx86op2DD3nY=",
+          "optional": true,
+          "requires": {
+            "datatables.net": "1.10.16",
+            "jquery": ">=1.7"
+          }
+        },
+        "datatables.net-colreorder": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-1.4.1.tgz",
+          "integrity": "sha1-OJ5LGidOIDl5o3GNhsWITQoBZrY=",
+          "optional": true,
+          "requires": {
+            "datatables.net": "^1.10.15",
+            "jquery": ">=1.7"
+          }
+        },
+        "datatables.net-colreorder-bs": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/datatables.net-colreorder-bs/-/datatables.net-colreorder-bs-1.3.3.tgz",
+          "integrity": "sha1-Op3LCN7r612FQHlZHgbkk615OlM=",
+          "optional": true,
+          "requires": {
+            "datatables.net-bs": ">=1.10.9",
+            "datatables.net-colreorder": ">=1.2.0",
+            "jquery": ">=1.7"
+          }
+        },
+        "datatables.net-select": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/datatables.net-select/-/datatables.net-select-1.2.5.tgz",
+          "integrity": "sha1-T3ZGabRk1VdqWcV2wSUKXQaaouk=",
+          "optional": true,
+          "requires": {
+            "datatables.net": "^1.10.15",
+            "jquery": ">=1.7"
+          }
+        },
+        "drmonty-datatables-colvis": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/drmonty-datatables-colvis/-/drmonty-datatables-colvis-1.1.2.tgz",
+          "integrity": "sha1-lque37SGQ8wu3aP4e4iTPN7oEnw=",
+          "optional": true,
+          "requires": {
+            "jquery": ">=1.7.0"
+          }
+        },
+        "eonasdan-bootstrap-datetimepicker": {
+          "version": "4.17.47",
+          "resolved": "https://registry.npmjs.org/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.47.tgz",
+          "integrity": "sha1-ekmXAEQGUnbnll79Fvgic1IZ5zU=",
+          "optional": true,
+          "requires": {
+            "bootstrap": "^3.3",
+            "jquery": "^1.8.3 || ^2.0 || ^3.0",
+            "moment": "^2.10",
+            "moment-timezone": "^0.4.0"
+          }
+        },
+        "font-awesome": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+          "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+        },
+        "google-code-prettify": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/google-code-prettify/-/google-code-prettify-1.0.5.tgz",
+          "integrity": "sha1-n0d/Ik2/piNy5e+AOn4VdBBAAIQ=",
+          "optional": true
+        },
+        "jquery": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+          "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
+        },
+        "jquery-match-height": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/jquery-match-height/-/jquery-match-height-0.7.2.tgz",
+          "integrity": "sha1-+NnzulMU2qsQnPB0CGdL4gS+Xw4=",
+          "optional": true
+        },
+        "moment": {
+          "version": "2.22.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+          "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+        },
+        "moment-timezone": {
+          "version": "0.4.1",
+          "resolved": "http://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
+          "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
+          "optional": true,
+          "requires": {
+            "moment": ">= 2.6.0"
+          }
+        },
+        "patternfly": {
+          "version": "3.48.1",
+          "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.48.1.tgz",
+          "integrity": "sha1-4A+488ueUzhQheqoHtHFpCJuyNM=",
+          "requires": {
+            "@types/c3": "^0.6.0",
+            "bootstrap": "~3.3.7",
+            "bootstrap-datepicker": "^1.7.1",
+            "bootstrap-sass": "^3.3.7",
+            "bootstrap-select": "1.12.2",
+            "bootstrap-slider": "^9.9.0",
+            "bootstrap-switch": "~3.3.4",
+            "bootstrap-touchspin": "~3.1.1",
+            "c3": "~0.4.11",
+            "d3": "~3.5.17",
+            "datatables.net": "^1.10.15",
+            "datatables.net-colreorder": "^1.4.1",
+            "datatables.net-colreorder-bs": "~1.3.2",
+            "datatables.net-select": "~1.2.0",
+            "drmonty-datatables-colvis": "~1.1.2",
+            "eonasdan-bootstrap-datetimepicker": "^4.17.47",
+            "font-awesome": "^4.7.0",
+            "font-awesome-sass": "^4.7.0",
+            "google-code-prettify": "~1.0.5",
+            "jquery": "~3.2.1",
+            "jquery-match-height": "^0.7.2",
+            "moment": "^2.19.1",
+            "moment-timezone": "^0.4.1",
+            "patternfly-bootstrap-combobox": "~1.1.7",
+            "patternfly-bootstrap-treeview": "~2.1.0"
+          },
+          "dependencies": {
+            "@types/c3": {
+              "version": "0.6.0",
+              "resolved": "http://registry.npmjs.org/@types/c3/-/c3-0.6.0.tgz",
+              "integrity": "sha512-49E+Oh7KDKd8Dg4WjYh8NvFSZlmPUYuNquJzTvhk+CaBhsN7z+m1U/jmGS4V2QWHxBwj1HT7Hdz2mWbRXEmjQA==",
+              "optional": true,
+              "requires": {
+                "@types/d3": "^4"
+              }
+            },
+            "@types/d3": {
+              "version": "4.13.0",
+              "resolved": "http://registry.npmjs.org/@types/d3/-/d3-4.13.0.tgz",
+              "integrity": "sha512-L7C+aOIl+z/e7pPBvRXxA9EZ8a5RIZSq4UnTgdjCnypYV3bPI1wpx81snC8pE1zB4SZQC/WK4noZUHzWAABfBA==",
+              "optional": true,
+              "requires": {
+                "@types/d3-array": "*",
+                "@types/d3-axis": "*",
+                "@types/d3-brush": "*",
+                "@types/d3-chord": "*",
+                "@types/d3-collection": "*",
+                "@types/d3-color": "*",
+                "@types/d3-dispatch": "*",
+                "@types/d3-drag": "*",
+                "@types/d3-dsv": "*",
+                "@types/d3-ease": "*",
+                "@types/d3-force": "*",
+                "@types/d3-format": "*",
+                "@types/d3-geo": "*",
+                "@types/d3-hierarchy": "*",
+                "@types/d3-interpolate": "*",
+                "@types/d3-path": "*",
+                "@types/d3-polygon": "*",
+                "@types/d3-quadtree": "*",
+                "@types/d3-queue": "*",
+                "@types/d3-random": "*",
+                "@types/d3-request": "*",
+                "@types/d3-scale": "^1",
+                "@types/d3-selection": "*",
+                "@types/d3-shape": "*",
+                "@types/d3-time": "*",
+                "@types/d3-time-format": "*",
+                "@types/d3-timer": "*",
+                "@types/d3-transition": "*",
+                "@types/d3-voronoi": "*",
+                "@types/d3-zoom": "*"
+              }
+            },
+            "@types/d3-array": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.1.tgz",
+              "integrity": "sha512-YBaAfimGdWE4nDuoGVKsH89/dkz2hWZ0i8qC+xxqmqi+XJ/aXiRF0jPtzXmN7VdkpVjy1xuDmM5/m1FNuB6VWA==",
+              "optional": true
+            },
+            "@types/d3-axis": {
+              "version": "1.0.10",
+              "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.10.tgz",
+              "integrity": "sha512-5YF0wfdQMPKw01VAAupLIlg/T4pn5M3/vL9u0KZjiemnVnnKBEWE24na4X1iW+TfZiYJ8j+BgK2KFYnAAT54Ug==",
+              "optional": true,
+              "requires": {
+                "@types/d3-selection": "*"
+              }
+            },
+            "@types/d3-brush": {
+              "version": "1.0.8",
+              "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.0.8.tgz",
+              "integrity": "sha512-9Thv09jvolu9T1BE3fHmIeYSgbwSpdxtF6/A5HZEDjSTfgtA0mtaXRk5AiWOo0KjuLsI+/7ggD3ZGN5Ye8KXPQ==",
+              "optional": true,
+              "requires": {
+                "@types/d3-selection": "*"
+              }
+            },
+            "@types/d3-chord": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.7.tgz",
+              "integrity": "sha512-WbCN7SxhZMpQQw46oSjAovAmvl3IdjhLuQ4r7AXCzNKyxtXXBWuihSPZ4bVwFQF3+S2z37i9d4hfUBatcSJpog==",
+              "optional": true
+            },
+            "@types/d3-collection": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-collection/-/d3-collection-1.0.7.tgz",
+              "integrity": "sha512-vR3BT0GwHc5y93Jv6bxn3zoxP/vGu+GdXu/r1ApjbP9dLk9I2g6NiV7iP/QMQSuFZd0It0n/qWrfXHxCWwHIkg==",
+              "optional": true
+            },
+            "@types/d3-color": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.2.1.tgz",
+              "integrity": "sha512-xwb1tqvYNWllbHuhMFhiXk63Imf+QNq/dJdmbXmr2wQVnwGenCuj3/0IWJ9hdIFQIqzvhT7T37cvx93jtAsDbQ=="
+            },
+            "@types/d3-dispatch": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+              "integrity": "sha512-xyWJQMr832vqhu6fD/YqX+MSFBWnkxasNhcStvlhqygXxj0cKqPft0wuGoH5TIq5ADXgP83qeNVa4R7bEYN3uA==",
+              "optional": true
+            },
+            "@types/d3-drag": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.1.tgz",
+              "integrity": "sha512-J9liJ4NNeV0oN40MzPiqwWjqNi3YHCRtHNfNMZ1d3uL9yh1+vDuo346LBEr8yyBm30WHvrHssAkExVZrGCswtA==",
+              "optional": true,
+              "requires": {
+                "@types/d3-selection": "*"
+              }
+            },
+            "@types/d3-dsv": {
+              "version": "1.0.33",
+              "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.0.33.tgz",
+              "integrity": "sha512-jx5YvaVC3Wfh6LobaiWTeU1NkvL2wPmmpmajk618bD+xVz98yNWzmZMvmlPHGK0HXbMeHmW/6oVX48V9AH1bRQ=="
+            },
+            "@types/d3-ease": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.7.tgz",
+              "integrity": "sha1-k6MBhovp4VBh89RDQ7GrP4rLbwk=",
+              "optional": true
+            },
+            "@types/d3-force": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.1.1.tgz",
+              "integrity": "sha512-ePkELuaFWY4yOuf+Bvx5Xd+ihFiYG4bdnW0BlvigovIm8Sob2t76e9RGO6lybQbv6AlW9Icn9HuZ9fmdzEoJyg==",
+              "optional": true
+            },
+            "@types/d3-format": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.3.0.tgz",
+              "integrity": "sha512-ZiY4j3iJvAdOwzwW24WjlZbUNvqOsnPAMfPBmdXqxj3uKJbrzBlRrdGl5uC89pZpFs9Dc92E81KcwG2uEgkIZA==",
+              "optional": true
+            },
+            "@types/d3-geo": {
+              "version": "1.10.3",
+              "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.10.3.tgz",
+              "integrity": "sha512-hfdaxM2L0wA9mDZrrSf2o+DyhEpnJYCiAN+lHFtpfZOVCQrYBA5g33sGRpUbAvjSMyO5jkHbftMWPEhuCMChSg==",
+              "optional": true,
+              "requires": {
+                "@types/geojson": "*"
+              }
+            },
+            "@types/d3-hierarchy": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.2.tgz",
+              "integrity": "sha512-L+Ht4doqlCIH8jYN2AC1mYIOj13OxlRhdWNWXv2pc3o5A9i3YmQ0kz6A7w8c+Ujylfusi/FO+zVlVnQoOHc2Qw==",
+              "optional": true
+            },
+            "@types/d3-interpolate": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
+              "integrity": "sha1-ZAQbFcnAMsNI2hsiuqvFn6TRYTY=",
+              "requires": {
+                "@types/d3-color": "*"
+              }
+            },
+            "@types/d3-path": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.7.tgz",
+              "integrity": "sha512-U8dFRG+8WhkLJr2sxZ9Cw/5WeRgBnNqMxGdA1+Z0+ZG6tK0s75OQ4OXnxeyfKuh6E4wQPY8OAKr1+iNDx01BEQ=="
+            },
+            "@types/d3-polygon": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.6.tgz",
+              "integrity": "sha512-E6Kyodn9JThgLq20nxSbEce9ow5/ePgm9PX2EO6W1INIL4DayM7cFaiG10DStuamjYAd0X4rntW2q+GRjiIktw==",
+              "optional": true
+            },
+            "@types/d3-quadtree": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.5.tgz",
+              "integrity": "sha1-HOHmWerkUw3wyxJ/KX8XQaNnqC4=",
+              "optional": true
+            },
+            "@types/d3-queue": {
+              "version": "3.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-queue/-/d3-queue-3.0.6.tgz",
+              "integrity": "sha512-CGGs7QeUs4F9YoD7KM0l4jwQ3wj2UqVLIweRk/OxF5n3ujnSJoT/wzIl2TCR0TiY88LEAnBfW+LhEJm9famk6A==",
+              "optional": true
+            },
+            "@types/d3-random": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.1.tgz",
+              "integrity": "sha512-jUPeBq1XKK9/5XasTvy5QAUwFeMsjma2yt/nP02yC2Tijovx7i/W5776U/HZugxc5SSmtpx4Z3g9KFVon0QrjQ==",
+              "optional": true
+            },
+            "@types/d3-request": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/@types/d3-request/-/d3-request-1.0.2.tgz",
+              "integrity": "sha1-2524FU9HgWWEcGxub3Ar5m8i9L4=",
+              "optional": true,
+              "requires": {
+                "@types/d3-dsv": "*"
+              }
+            },
+            "@types/d3-scale": {
+              "version": "1.0.13",
+              "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-1.0.13.tgz",
+              "integrity": "sha512-VkytFyGGRVNBn/CBfvstjta9elXALBAgg9yTqHHAglOTTR8EhPDQYBnMwE2kOYxu32kBXzUNXKdFCA9YejKjnw==",
+              "optional": true,
+              "requires": {
+                "@types/d3-time": "*"
+              }
+            },
+            "@types/d3-selection": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.3.1.tgz",
+              "integrity": "sha512-G+eO+2G1iW3GNrROxhoU+ar+bIJbQq1QkxcfhwjQ19xA20n3T31j5pSJqAOWvPSoFTz4Ets/DQgYhmgT4jepDg=="
+            },
+            "@types/d3-shape": {
+              "version": "1.2.3",
+              "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.2.3.tgz",
+              "integrity": "sha512-iP9TcX0EVi+LlX+jK9ceS+yhEz5abTitF+JaO2ugpRE/J+bccaYLe/0/3LETMmdaEkYarIyboZW8OF67Mpnj1w==",
+              "optional": true,
+              "requires": {
+                "@types/d3-path": "*"
+              }
+            },
+            "@types/d3-time": {
+              "version": "1.0.8",
+              "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.0.8.tgz",
+              "integrity": "sha512-/UCphyyw97YAq4zKsuXH33R3UNB4jDSza0fLvMubWr/ONh9IePi1NbgFP222blhiCe724ebJs8U87+aDuAq/jA=="
+            },
+            "@types/d3-time-format": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
+              "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==",
+              "optional": true
+            },
+            "@types/d3-timer": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.6.tgz",
+              "integrity": "sha1-eG1OIHMa3wOvLF32yG/ilmf+Qps=",
+              "optional": true
+            },
+            "@types/d3-transition": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.1.1.tgz",
+              "integrity": "sha512-GHTghl0YYB8gGgbyKxVLHyAp9Na0HqsX2U7M0u0lGw4IdfEaslooykweZ8fDHW13T+KZeZAuzhbmqBZVFO+6kg==",
+              "optional": true,
+              "requires": {
+                "@types/d3-selection": "*"
+              }
+            },
+            "@types/d3-voronoi": {
+              "version": "1.1.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.7.tgz",
+              "integrity": "sha512-/dHFLK5jhXTb/W4XEQcFydVk8qlIAo85G3r7+N2fkBFw190l0R1GQ8C1VPeXBb2GfSU5GbT2hjlnE7i7UY5Gvg==",
+              "optional": true
+            },
+            "@types/d3-zoom": {
+              "version": "1.7.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.7.1.tgz",
+              "integrity": "sha512-Ofjwz6Pt53tRef9TAwwayN+JThNVYC/vFOepa/H4KtwjhsqkmEseHvc2jpJM7vye5PQ5XHtTSOpdY4Y/6xZWEg==",
+              "optional": true,
+              "requires": {
+                "@types/d3-interpolate": "*",
+                "@types/d3-selection": "*"
+              }
+            },
+            "@types/geojson": {
+              "version": "7946.0.3",
+              "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.3.tgz",
+              "integrity": "sha512-BYHiG1vQJ7T93uswzuXZ0OBPWqj5tsAPtaMDQADV8sn2InllXarwg9llr6uaW22q1QCwBZ81gVajOpYWzjesug==",
+              "optional": true
+            },
+            "bootstrap": {
+              "version": "3.3.7",
+              "resolved": "http://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+              "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
+            },
+            "bootstrap-datepicker": {
+              "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.8.0.tgz",
+              "integrity": "sha512-213St/G8KT3mjs4qu4qwww74KWysMaIeqgq5OhrboZjIjemIpyuxlSo9FNNI5+KzpkkxkRRba+oewiRGV42B1A==",
+              "optional": true,
+              "requires": {
+                "jquery": ">=1.7.1 <4.0.0"
+              }
+            },
+            "bootstrap-sass": {
+              "version": "3.3.7",
+              "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
+              "integrity": "sha1-ZZbHq0D2Y3OTMjqwvIDQZPxjBJg=",
+              "optional": true
+            },
+            "bootstrap-select": {
+              "version": "1.12.2",
+              "resolved": "https://registry.npmjs.org/bootstrap-select/-/bootstrap-select-1.12.2.tgz",
+              "integrity": "sha1-WNCVs/1YSzFEOGb745tv3U5OEqQ=",
+              "optional": true,
+              "requires": {
+                "jquery": ">=1.8"
+              }
+            },
+            "bootstrap-slider": {
+              "version": "9.10.0",
+              "resolved": "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-9.10.0.tgz",
+              "integrity": "sha1-EQPWvADPv6jPyaJZmrUYxVZD2j8=",
+              "optional": true
+            },
+            "bootstrap-switch": {
+              "version": "3.3.4",
+              "resolved": "https://registry.npmjs.org/bootstrap-switch/-/bootstrap-switch-3.3.4.tgz",
+              "integrity": "sha1-cOCusqh3wNx2aZHeEI4hcPwpov8=",
+              "optional": true
+            },
+            "bootstrap-touchspin": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/bootstrap-touchspin/-/bootstrap-touchspin-3.1.1.tgz",
+              "integrity": "sha1-l3nerHKq9Xfl52K4USx0fIcdlZc=",
+              "optional": true
+            },
+            "c3": {
+              "version": "0.4.23",
+              "resolved": "https://registry.npmjs.org/c3/-/c3-0.4.23.tgz",
+              "integrity": "sha512-fI6hbx1QoATU0gRQtPWsUGWX+ssXhxGH1ogew32KjVmGHFE4WmfmBkh+RkuHDoeCIoGFon7XTpKcwUZpBGW4mQ==",
+              "optional": true,
+              "requires": {
+                "d3": "~3.5.0"
+              }
+            },
+            "d3": {
+              "version": "3.5.17",
+              "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+              "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=",
+              "optional": true
+            },
+            "datatables.net": {
+              "version": "1.10.16",
+              "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.16.tgz",
+              "integrity": "sha1-SwUtEIKCQmG2ju2dInQbcR09JGk=",
+              "requires": {
+                "jquery": ">=1.7"
+              }
+            },
+            "datatables.net-bs": {
+              "version": "1.10.16",
+              "resolved": "https://registry.npmjs.org/datatables.net-bs/-/datatables.net-bs-1.10.16.tgz",
+              "integrity": "sha1-sIVPWzdPcTrj20FWx86op2DD3nY=",
+              "optional": true,
+              "requires": {
+                "datatables.net": "1.10.16",
+                "jquery": ">=1.7"
+              }
+            },
+            "datatables.net-colreorder": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-1.4.1.tgz",
+              "integrity": "sha1-OJ5LGidOIDl5o3GNhsWITQoBZrY=",
+              "optional": true,
+              "requires": {
+                "datatables.net": "^1.10.15",
+                "jquery": ">=1.7"
+              }
+            },
+            "datatables.net-colreorder-bs": {
+              "version": "1.3.3",
+              "resolved": "https://registry.npmjs.org/datatables.net-colreorder-bs/-/datatables.net-colreorder-bs-1.3.3.tgz",
+              "integrity": "sha1-Op3LCN7r612FQHlZHgbkk615OlM=",
+              "optional": true,
+              "requires": {
+                "datatables.net-bs": ">=1.10.9",
+                "datatables.net-colreorder": ">=1.2.0",
+                "jquery": ">=1.7"
+              }
+            },
+            "datatables.net-select": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/datatables.net-select/-/datatables.net-select-1.2.5.tgz",
+              "integrity": "sha1-T3ZGabRk1VdqWcV2wSUKXQaaouk=",
+              "optional": true,
+              "requires": {
+                "datatables.net": "^1.10.15",
+                "jquery": ">=1.7"
+              }
+            },
+            "drmonty-datatables-colvis": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/drmonty-datatables-colvis/-/drmonty-datatables-colvis-1.1.2.tgz",
+              "integrity": "sha1-lque37SGQ8wu3aP4e4iTPN7oEnw=",
+              "optional": true,
+              "requires": {
+                "jquery": ">=1.7.0"
+              }
+            },
+            "eonasdan-bootstrap-datetimepicker": {
+              "version": "4.17.47",
+              "resolved": "https://registry.npmjs.org/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.47.tgz",
+              "integrity": "sha1-ekmXAEQGUnbnll79Fvgic1IZ5zU=",
+              "optional": true,
+              "requires": {
+                "bootstrap": "^3.3",
+                "jquery": "^1.8.3 || ^2.0 || ^3.0",
+                "moment": "^2.10",
+                "moment-timezone": "^0.4.0"
+              }
+            },
+            "font-awesome": {
+              "version": "4.7.0",
+              "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+              "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+            },
+            "font-awesome-sass": {
+              "version": "4.7.0",
+              "resolved": "https://registry.npmjs.org/font-awesome-sass/-/font-awesome-sass-4.7.0.tgz",
+              "integrity": "sha1-TtppPpFQCc4Asijglk3F7Km8NOE=",
+              "optional": true
+            },
+            "google-code-prettify": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/google-code-prettify/-/google-code-prettify-1.0.5.tgz",
+              "integrity": "sha1-n0d/Ik2/piNy5e+AOn4VdBBAAIQ=",
+              "optional": true
+            },
+            "jquery": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+              "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
+            },
+            "jquery-match-height": {
+              "version": "0.7.2",
+              "resolved": "https://registry.npmjs.org/jquery-match-height/-/jquery-match-height-0.7.2.tgz",
+              "integrity": "sha1-+NnzulMU2qsQnPB0CGdL4gS+Xw4=",
+              "optional": true
+            },
+            "moment": {
+              "version": "2.22.1",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+              "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+            },
+            "moment-timezone": {
+              "version": "0.4.1",
+              "resolved": "http://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
+              "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
+              "optional": true,
+              "requires": {
+                "moment": ">= 2.6.0"
+              }
+            },
+            "patternfly-bootstrap-combobox": {
+              "version": "1.1.7",
+              "resolved": "https://registry.npmjs.org/patternfly-bootstrap-combobox/-/patternfly-bootstrap-combobox-1.1.7.tgz",
+              "integrity": "sha1-al48zRFwwhs8S0qhaKdBPh3btuE=",
+              "optional": true
+            },
+            "patternfly-bootstrap-treeview": {
+              "version": "2.1.5",
+              "resolved": "https://registry.npmjs.org/patternfly-bootstrap-treeview/-/patternfly-bootstrap-treeview-2.1.5.tgz",
+              "integrity": "sha1-TCnyWC+4ovKPCpKPLw0yTSHWmQ0=",
+              "optional": true,
+              "requires": {
+                "bootstrap": "3.3.x",
+                "jquery": ">= 2.1.x"
+              }
+            }
+          }
+        },
+        "patternfly-bootstrap-combobox": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/patternfly-bootstrap-combobox/-/patternfly-bootstrap-combobox-1.1.7.tgz",
+          "integrity": "sha1-al48zRFwwhs8S0qhaKdBPh3btuE=",
+          "optional": true
+        },
+        "patternfly-bootstrap-treeview": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/patternfly-bootstrap-treeview/-/patternfly-bootstrap-treeview-2.1.5.tgz",
+          "integrity": "sha1-TCnyWC+4ovKPCpKPLw0yTSHWmQ0=",
+          "optional": true,
+          "requires": {
+            "bootstrap": "3.3.x",
+            "jquery": ">= 2.1.x"
+          }
+        }
+      }
     },
     "read-cache": {
       "version": "1.0.0",

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -21,7 +21,9 @@
   "jest": {
     "preset": "jest-preset-angular",
     "setupTestFrameworkScriptFile": "<rootDir>/src/setupJest.ts",
-    "transformIgnorePatterns": ["node_modules/(?!@ngrx|ngx-bootstrap|@progress)"],
+    "transformIgnorePatterns": [
+      "node_modules/(?!@ngrx|ngx-bootstrap|@progress)"
+    ],
     "transform": {
       "^.+\\.(ts|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js",
       "^.+\\.js$": "babel-jest"


### PR DESCRIPTION
This includes the fix for rhbz#1647812 - Ceph-Mgr does not properly feed mgr's perf_counter schema (the part where ceph-mgr metadata is missing). It also contains a fix for the issue with package-lock.json file that I hit while testing the back-port/trying to build the branch.

The fix for rhbz#1647812 includes fixes for:

https://tracker.ceph.com/issues/23330
https://tracker.ceph.com/issues/23286

This results in the back-port of the following PRs (all the patches applied cleanly) :

https://github.com/ceph/ceph/pull/20866
https://github.com/ceph/ceph/pull/20875