### PR TITLE
Adds branding to progress bar

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.scss
@@ -1,0 +1,11 @@
+@import '../../../../branding/branding';
+
+.progress-bar {
+  background-color: $color-patternfly-progressbar !important;
+  -webkit-box-shadow: $shadow-patternfly-progressbar;
+  box-shadow: $shadow-patternfly-progressbar;
+}
+
+.progress-bar-info {
+  background-color: $color-patternfly-progressinfo !important;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/branding/branding.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/branding/branding.scss
@@ -3,6 +3,7 @@
 $color-copper-black: #4d5258;
 $color-sea-blue: #0088ce;
 $color-dark-sea-blue: #00659c;
+$color-patternfly-blue: #39a5dc;
 
 /* Login Screen */
 $color-languages: $color-black;
@@ -12,3 +13,8 @@ $color-selected-language: $color-copper-black;
 $color-patternfly-button-background: $color-sea-blue;
 $color-patternfly-button-border: $color-dark-sea-blue;
 $color-disabled-button: $color-white-gray;
+
+/* Progress Bar */
+$color-patternfly-progressbar: $color-grad-gray;
+$shadow-patternfly-progressbar: inset 0 0 1px rgba(3, 3, 3, 0.25);
+$color-patternfly-progressinfo: $color-patternfly-blue;


### PR DESCRIPTION
Before:
1. 1st row hover, last row selected
![screenshot from 2019-01-22 13-20-02](https://user-images.githubusercontent.com/12200504/51520963-23972800-1e4b-11e9-8e11-a6b9ce37209c.png)
2. No row is selected
![screenshot from 2019-01-22 13-19-47](https://user-images.githubusercontent.com/12200504/51520964-23972800-1e4b-11e9-9da5-1887580977b0.png)

After:
1. 1st row hover, last row selected
![screenshot from 2019-01-22 13-14-50](https://user-images.githubusercontent.com/12200504/51520969-2bef6300-1e4b-11e9-91ed-1f870165b45a.png)
2. No row is selected
![screenshot from 2019-01-22 13-14-26](https://user-images.githubusercontent.com/12200504/51520970-2c87f980-1e4b-11e9-98e3-be24b135a498.png)

Signed-off-by: Kanika Murarka <kmurarka@redhat.com>