### PR TITLE
Revert "github: Add CODEOWNERs for component/team reviews"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Dashboard team to review dashboard PRs
-/src/pybind/mgr/dashboard       @rhcs/dashboard


### PR DESCRIPTION
Reverts rhcs-dashboard/ceph#86