### PR TITLE
cephadm: defer RGW zone update if endpoints empty

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -703,6 +703,15 @@ class CephadmServe:
                         ep.append(f'{protocol}://{host_addr}:{p}')
                     else:
                         logger.error("Hostname is None for service: %s", s)
+
+        if not ep:
+            self.log.warning(
+                "Computed endpoints are empty for service %s; deferring zone update",
+                rgw_spec.service_name()
+            )
+            rgw_spec.update_endpoints = True
+            return
+
         zone_update_cmd = {
             'prefix': 'rgw zone modify',
             'realm_name': rgw_spec.rgw_realm,

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -689,7 +689,13 @@ class CephadmServe:
 
         ep = []
         protocol = 'https' if rgw_spec.ssl else 'http'
-        for s in self.mgr.cache.get_daemons_by_service(rgw_spec.service_name()):
+        daemons = self.mgr.cache.get_daemons_by_service(rgw_spec.service_name())
+        if not daemons:
+            self.log.debug(f'No rgw daemons found yet for \
+                service {rgw_spec.service_name()}, will retry')
+            return
+
+        for s in daemons:
             if s.ports:
                 for p in s.ports:
                     if s.hostname is not None:
@@ -713,6 +719,7 @@ class CephadmServe:
             self.mgr.set_health_warning('CEPHADM_RGW', 'Cannot update rgw endpoints, error: {err}', 1,
                                         [f'Cannot update rgw endpoints for daemon {rgw_spec.service_name()}, error: {err}'])
         else:
+            self.log.debug(f'Successfully updated rgw zone endpoints: {out}')
             self.mgr.remove_health_warning('CEPHADM_RGW')
 
     def _apply_service(self, spec: ServiceSpec) -> bool:


### PR DESCRIPTION
cephadm: defer RGW zone update if endpoints empty

We hit an async race where cephadm tried to update RGW with zone_endpoints=[] before any RGW daemon had a usable IP, causing realms to show ‘master zone has no endpoint’; the ep non-empty check defers the write until endpoints are discovered, preventing us from committing an empty list and breaking tokens/period updates.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
